### PR TITLE
simplify principal parsing

### DIFF
--- a/packages/@aws-cdk/aws-iam/lib/policy-statement.ts
+++ b/packages/@aws-cdk/aws-iam/lib/policy-statement.ts
@@ -1,6 +1,6 @@
 import * as cdk from '@aws-cdk/core';
 import { AccountPrincipal, AccountRootPrincipal, Anyone, ArnPrincipal, CanonicalUserPrincipal,
-  FederatedPrincipal, IPrincipal, ServicePrincipal, ServicePrincipalOpts } from './principals';
+  FederatedPrincipal, IPrincipal, PrincipalBase, PrincipalPolicyFragment, ServicePrincipal, ServicePrincipalOpts } from './principals';
 import { mergePrincipal } from './util';
 
 const ensureArrayOrUndefined = (field: any) => {
@@ -27,32 +27,19 @@ export class PolicyStatement {
    * @param obj the PolicyStatement in object form.
    */
   public static fromJson(obj: any) {
-    const statement = new PolicyStatement({
+    return new PolicyStatement({
+      sid: obj.Sid,
       actions: ensureArrayOrUndefined(obj.Action),
       resources: ensureArrayOrUndefined(obj.Resource),
       conditions: obj.Condition,
       effect: obj.Effect,
       notActions: ensureArrayOrUndefined(obj.NotAction),
-      notResources: ensureArrayOrUndefined(obj.NotResource)
+      notResources: ensureArrayOrUndefined(obj.NotResource),
+      principals: obj.Principal ? [ new JsonPrincipal(obj.Principal) ] : undefined,
+      notPrincipals: obj.NotPrincipal ? [ new JsonPrincipal(obj.NotPrincipal) ] : undefined
     });
-
-    statement.sid = obj.Sid;
-
-    // Since the principals are a more complex object, not just a string or an array of strings,
-    // then just passing them through on the constructor doesn't work.
-    if (obj.Principal) {
-      /* tslint:disable:no-unused-expression */
-      obj.Principal === "*" && statement.addAnyPrincipal();
-      obj.Principal.AWS && statement.addArnPrincipal(obj.Principal.AWS);
-      obj.Principal.CanonicalUser && statement.addCanonicalUserPrincipal(obj.Principal.CanonicalUser);
-      obj.Principal.Federated && statement.addFederatedPrincipal(obj.Principal.Federated, {});
-      obj.Principal.Service && statement.addServicePrincipal(obj.Principal.Service.replace(/.amazonaws.com/i, ''));
-      /* tslint:enable:no-unused-expression */
-    }
-
-    return statement;
-
   }
+
   /**
    * Statement ID for this statement
    */
@@ -75,6 +62,7 @@ export class PolicyStatement {
       }
     }
 
+    this.sid = props.sid;
     this.effect = props.effect || Effect.ALLOW;
 
     this.addActions(...props.actions || []);
@@ -319,6 +307,15 @@ export enum Effect {
  */
 export interface PolicyStatementProps {
   /**
+   * The Sid (statement ID) is an optional identifier that you provide for the
+   * policy statement. You can assign a Sid value to each statement in a
+   * statement array. In services that let you specify an ID element, such as
+   * SQS and SNS, the Sid value is just a sub-ID of the policy document's ID. In
+   * IAM, the Sid value must be unique within a JSON policy.
+   */
+  readonly sid?: string;
+
+  /**
    * List of actions to add to the statement
    *
    * @default - no actions
@@ -383,4 +380,22 @@ function noUndef(x: any): any {
     }
   }
   return ret;
+}
+
+class JsonPrincipal extends PrincipalBase {
+  public readonly policyFragment: PrincipalPolicyFragment;
+
+  constructor(json: any = { }) {
+    super();
+
+    // special case: if principal is a string, turn it into an "AWS" principal
+    if (typeof(json) === 'string') {
+      json = { AWS: json };
+    }
+
+    this.policyFragment = {
+      principalJson: json,
+      conditions: []
+    };
+  }
 }

--- a/packages/@aws-cdk/aws-iam/lib/util.ts
+++ b/packages/@aws-cdk/aws-iam/lib/util.ts
@@ -69,9 +69,9 @@ export function mergePrincipal(target: { [key: string]: string[] }, source: { [k
   for (const key of Object.keys(source)) {
     target[key] = target[key] || [];
 
-    const value = source[key];
+    let value = source[key];
     if (!Array.isArray(value)) {
-      throw new Error(`Principal value must be an array (it will be normalized later): ${value}`);
+      value = [ value ];
     }
 
     target[key].push(...value);


### PR DESCRIPTION
Use a "raw" principal class that implements IPrincipal in order to simplify parsing of Principal and NotPrincipal in fromJson.

